### PR TITLE
updating logstash version to avoid issue with permissions. 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM hpess/jre:master
 MAINTAINER Karl Stoney <karl.stoney@hp.com> 
 
-ENV LS_PKG_NAME logstash-1.5.0
+ENV LS_PKG_NAME logstash-1.5.1
 
 # Install logstash.
 RUN cd /opt && \


### PR DESCRIPTION
https://github.com/elastic/logstash/issues/3249#event-315149287

Docker container is not starting. Failing with permissions errors on /opt/logstash/.bundle/config
